### PR TITLE
Remove codecov github action since the Ruby gem automatically sends the coverage report to Codecov

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -97,8 +97,3 @@ jobs:
           PGPASSWORD: postgres
           COVERAGE: true
         run: bundle exec rspec
-      - name: CodeCov
-        uses: codecov/codecov-action@v1
-        with:
-          directory: coverage
-          file: ./coverage/.resultset.json


### PR DESCRIPTION
…